### PR TITLE
Fix setting the cache prefix on hierarchical subcaches

### DIFF
--- a/Concentrate/CacheAPC.php
+++ b/Concentrate/CacheAPC.php
@@ -22,7 +22,7 @@ class Concentrate_CacheAPC extends Concentrate_CacheHierarchyAbstract
 		$this->extraPrefix = strval($extraPrefix);
 	}
 
-	public function setPrefix($prefix)
+	public function setPrefixSelf($prefix)
 	{
 		$this->prefix = strval($prefix);
 	}

--- a/Concentrate/CacheArray.php
+++ b/Concentrate/CacheArray.php
@@ -13,7 +13,7 @@ class Concentrate_CacheArray extends Concentrate_CacheHierarchyAbstract
 {
 	protected $data = array();
 
-	public function setPrefix($prefix)
+	public function setPrefixSelf($prefix)
 	{
 		// do nothing since array is not saved between requests
 	}

--- a/Concentrate/CacheHierarchyAbstract.php
+++ b/Concentrate/CacheHierarchyAbstract.php
@@ -56,9 +56,19 @@ abstract class Concentrate_CacheHierarchyAbstract
 		return $response;
 	}
 
+	public function setPrefix($prefix)
+	{
+		$this->setPrefixSelf($prefix);
+
+		if ($this->subcache !== null) {
+			$this->subcache->setPrefix($prefix);
+		}
+	}
+
 	abstract protected function setSelf($key, $value);
 	abstract protected function getSelf($key);
 	abstract protected function deleteSelf($key);
+	abstract protected function setPrefixSelf($prefix);
 }
 
 ?>

--- a/Concentrate/CacheMemcache.php
+++ b/Concentrate/CacheMemcache.php
@@ -51,7 +51,6 @@ class Concentrate_CacheMemcache extends Concentrate_CacheHierarchyAbstract
 		if ($this->extraPrefix != '') {
 			$key = $this->extraPrefix . ':' . $key;
 		}
-		echo $key,"<br/>";
 
 		return $key;
 	}

--- a/Concentrate/CacheMemcache.php
+++ b/Concentrate/CacheMemcache.php
@@ -22,7 +22,7 @@ class Concentrate_CacheMemcache extends Concentrate_CacheHierarchyAbstract
 		$this->memcache    = $memcache;
 	}
 
-	public function setPrefix($prefix)
+	public function setPrefixSelf($prefix)
 	{
 		$this->prefix = strval($prefix);
 	}
@@ -51,6 +51,7 @@ class Concentrate_CacheMemcache extends Concentrate_CacheHierarchyAbstract
 		if ($this->extraPrefix != '') {
 			$key = $this->extraPrefix . ':' . $key;
 		}
+		echo $key,"<br/>";
 
 		return $key;
 	}

--- a/Concentrate/Concentrator.php
+++ b/Concentrate/Concentrator.php
@@ -333,7 +333,7 @@ class Concentrate_Concentrator
 			// index by file, with values being the relative sort order
 			$fileSortOrder = array_flip($fileSortOrder);
 
-			$this->cache->set('fileSortOrder', $fileSortOrder);
+			$this->setCachedValue('fileSortOrder', $fileSortOrder);
 		}
 
 		return $fileSortOrder;
@@ -367,7 +367,7 @@ class Concentrate_Concentrator
 				}
 			}
 
-			$this->cache->set('fileInfo', $fileInfo);
+			$this->setCachedValue('fileInfo', $fileInfo);
 		}
 
 		return $fileInfo;
@@ -445,7 +445,7 @@ class Concentrate_Concentrator
 			// sort largest sets first
 			uasort($combinesInfo, array($this, 'compareCombines'));
 
-			$this->cache->set('combinesInfo', $combinesInfo);
+			$this->setCachedValue('combinesInfo', $combinesInfo);
 		}
 
 		return $combinesInfo;
@@ -499,7 +499,7 @@ class Concentrate_Concentrator
 				}
 			}
 
-			$this->cache->set('dependsInfo', $dependsInfo);
+			$this->setCachedValue('dependsInfo', $dependsInfo);
 		}
 
 		return $dependsInfo;
@@ -639,7 +639,7 @@ class Concentrate_Concentrator
 			// sort order
 			$packageSortOrder = array_flip($order);
 
-			$this->cache->set('packageSortOrder', $packageSortOrder);
+			$this->setCachedValue('packageSortOrder', $packageSortOrder);
 		}
 
 		return $packageSortOrder;
@@ -668,6 +668,15 @@ class Concentrate_Concentrator
 	{
 		$this->cache->setPrefix($this->dataProvider->getCachePrefix());
 		return $this->cache->get($key);
+	}
+
+	// }}}
+	// {{{ setCachedValue()
+
+	protected function setCachedValue($key, $value)
+	{
+		$this->cache->setPrefix($this->dataProvider->getCachePrefix());
+		return $this->cache->set($key, $value);
 	}
 
 	// }}}

--- a/Concentrate/DataProvider.php
+++ b/Concentrate/DataProvider.php
@@ -96,7 +96,7 @@ class Concentrate_DataProvider
 				$key = md5(implode(':', $files));
 			}
 
-			$this->cachePrefix = 'concentrate:' . $key;
+			$this->cachePrefix = $key;
 		}
 
 		return $this->cachePrefix;


### PR DESCRIPTION
Before this change, only the top-level cache was namespaced with the hash of the file list.

https://www.pivotaltracker.com/story/show/92541454