### PR TITLE
Fix issue with URL rewriting for combined files.

### DIFF
--- a/Concentrate/CLI.php
+++ b/Concentrate/CLI.php
@@ -426,12 +426,12 @@ class Concentrate_CLI
 				// URIs within the CSS
 				if ($type === 'css') {
 					$fromFilterFile = ($directory == '')
-						? $file
-						: $directory . '/' . $file;
+						? $combine
+						: $directory . '/' . $combine;
 
 					$toFilterFile = ($directory =='')
-						? 'min/' . $file
-						: 'min/' . $directory . '/' . $file;
+						? 'min/' . $combine
+						: 'min/' . $directory . '/' . $combine;
 
 					$moveFilter = new Concentrate_Filter_CSSMover(
 						$fromFilterFile,
@@ -569,8 +569,8 @@ class Concentrate_CLI
 				}
 
 				$filter = new Concentrate_Filter_CSSMover(
-					$file,
-					'compiled/' . $file
+					$combine,
+					'compiled/' . $combine
 				);
 
 				$this->writeCompiledFile(


### PR DESCRIPTION
PT https://www.pivotaltracker.com/story/show/94606386

When compiling and minifying combined files, set the source and destination directories properly. Otherwise they get set randomly depending on what the last regular (non combined) file was.