### PR TITLE
Fix array structure when same file is parsed twice.

### DIFF
--- a/Concentrate/DataProvider.php
+++ b/Concentrate/DataProvider.php
@@ -79,7 +79,7 @@ class Concentrate_DataProvider
 				"Data file '{$filename}' is not valid YAML.",0, $filename);
 		}
 
-		$this->data = array_merge_recursive($this->data, $data);
+		$this->data = array_replace_recursive($this->data, $data);
 	}
 
 	public function getCachePrefix()


### PR DESCRIPTION
https://trello.com/c/t8uIPibW/1155-fix-php-warning-when-yaml-files-are-parsed-more-than-once

Using array_merge_recursive caused duplicate null values to turn into multi-element arrays containing null values. Using array_replace_recursive correctly merged multiple nulls into a single null.

Old behaviour:

```php
$a = array(
  'foo' => null,
);
$b = array(
  'foo' => null,
);
$c = array_merge_recursive($a, $b);
print_r($c);
// Array
// (
//   [foo] => Array
//     (
//       [0] =>
//       [1] =>
//     )
// )
```

New behaviour:
```php
$a = array(
  'foo' => null,
);
$b = array(
  'foo' => null,
);
$c = array_replace_recursive($a, $b);
print_r($c);
// Array
// (
//   [foo] =>
// )
```