### PR TITLE
Fix bootstrap autoloader configuration when used as library

### DIFF
--- a/scripts/concentrate
+++ b/scripts/concentrate
@@ -1,9 +1,20 @@
 #! /usr/bin/env php
 <?php
 
-$autoload = __DIR__ . '/../vendor/autoload.php';
-if (file_exists($autoload)) {
-	require_once $autoload;
+$autoloadPaths = array(
+	// Try to load autoloader if Concentrate is the root project.
+	__DIR__ . '/../vendor/autoload.php',
+
+	// Try to load an autoloader if Concentrate is installed as a library for
+	// another root project.
+	__DIR__ . '/../../../autoload.php',
+);
+
+foreach ($autoloadPaths as $path) {
+	if (file_exists($path)) {
+		require_once $path;
+		break;
+	}
 }
 
 require_once 'Concentrate/CLI.php';


### PR DESCRIPTION
https://trello.com/c/61Khgupt/1172-fix-issue-running-concentrate-when-installed-as-a-composer-module

Make bootstrap PHP script find autoloader when used both as a root project and as a library.