### PR TITLE
Update to use a locally-installed version of YUI compressor

### DIFF
--- a/Concentrate/Filter/Minifier/YUICompressor.php
+++ b/Concentrate/Filter/Minifier/YUICompressor.php
@@ -111,7 +111,15 @@ class Concentrate_Filter_Minifier_YUICompressor
     {
         $jarFile = '';
 
-        $paths = explode(PATH_SEPARATOR, get_include_path());
+        $paths = array(
+            // Try to load jar if Concentrate is the root project.
+            __DIR__ . '/../vendor/bin',
+
+            // Try to load jar if Concentrate is installed as a library for
+            // another root project.
+            __DIR__ . '/../../../bin',
+        );
+
         foreach ($paths as $path) {
             $dir = dir($path);
             while (false !== ($entry = $dir->read())) {

--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,7 @@
     "php": ">=5.6.0",
     "pear/pear-core-minimal": "^1.9.0",
     "pear/console_commandline": "^1.1.10",
+    "packagist/yuicompressor-bin": "^2.4.8",
     "symfony/yaml": "^3.0.0",
     "martin-pettersson/chalk": "^0.1.3"
   },


### PR DESCRIPTION
This removes the necessity of having YUI compressor installed in the system PEAR tree