### PR TITLE
Update symfony/yaml dependency major version

### DIFF
--- a/Concentrate/DataProvider.php
+++ b/Concentrate/DataProvider.php
@@ -71,7 +71,7 @@ class Concentrate_DataProvider
         }
 
         try {
-            $data = Yaml::parse(file_get_contents($filename));
+            $data = Yaml::parseFile($filename);
             $this->loadedFiles[] = $filename;
         } catch (InvalidArgumentException $e) {
             throw new Concentrate_FileFormatException(

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "ext-mbstring": "*",
     "pear/pear-core-minimal": "^1.9.0",
     "pear/console_commandline": "^1.1.10",
-    "symfony/yaml": "^3.0.0",
+    "symfony/yaml": "^5.4.0",
     "league/climate": "^3.5"
   },
   "require-dev": {


### PR DESCRIPTION
No major changes here. We only use the parser in one place, so the only
change was a convenience method added in a new version to read a file
and parse all in one.

Symfony/yaml changelog can be found here: https://github.com/symfony/yaml/blob/6.1/CHANGELOG.md

Only updating to 5.4 since 6.1 drops support for PHP7